### PR TITLE
Try using ember-css-modules

### DIFF
--- a/addon/components/tf-checkbox.js
+++ b/addon/components/tf-checkbox.js
@@ -2,6 +2,7 @@
   @module ember-ticketfly-checkbox
  */
 import layout from '../templates/components/tf-checkbox';
+import styles from '../styles/components/tf-checkbox';
 import get from 'ember-metal/get';
 import set from 'ember-metal/set';
 import Component from 'ember-component';
@@ -16,25 +17,26 @@ const DEFAULT_BOX_SHAPE = 'square';
  */
 export default Component.extend({
   layout,
+  styles,
 
   didReceiveAttrs() {
     this._super(...arguments);
 
     // if no checkboxId is supplied, generate one so that the label and checkbox can have one to share
     // for accessibility by default
-    if (!get(this, 'checkboxId')) { 
-      set(this, 'checkboxId', `id-${guidFor(this)}`); 
+    if (!get(this, 'checkboxId')) {
+      set(this, 'checkboxId', `id-${guidFor(this)}`);
     }
   },
 
-  classNames: ['c-tf-checkbox'],
+  localClassNames: ['tf-checkbox'],
 
   shouldShowCheck: computed.or('checked','disabled'),
 
   boxShape: computed('shapeStyle', {
     get() {
       const shapeStyle = get(this, 'shapeStyle') || DEFAULT_BOX_SHAPE;
-      return `c-tf-checkbox__box-shape--${shapeStyle}`;
+      return `box-shape--${shapeStyle}`;
     }
   }),
 

--- a/addon/styles/components/tf-checkbox.css
+++ b/addon/styles/components/tf-checkbox.css
@@ -1,8 +1,8 @@
-/* 
-  Variables 
+/*
+  Variables
 */
 
-.c-tf-checkbox {
+.tf-checkbox {
   --tf-checkbox-min-width: 1.0625rem; /* 17px */
   --tf-checkbox-min-height: 1.0625rem; /* 17px */
   --tf-checkbox-border: 1px solid var(--x-color-gray-2);
@@ -11,11 +11,15 @@
   --tf-checkbox-border-radius-round: 10px;
 }
 
+.hidden-checkbox {
+  composes: u-hidden-visually u-m-0 from global;
+}
+
 /*
   Outline style (for accessibility when tabbing)
 */
 
-.c-tf-checkbox__input-checkbox:focus + .c-tf-checkbox__label {
+.hidden-checkbox:focus + .label {
   outline-style: auto;
 }
 
@@ -23,7 +27,8 @@
   Base Box Shape
 */
 
-.c-tf-checkbox__box-shape {
+.box-shape {
+  composes: u-inline-block u-valign-middle from global;
   border: var(--tf-checkbox-border);
   min-width: var(--tf-checkbox-min-width);
   min-height: var(--tf-checkbox-min-height);
@@ -33,11 +38,11 @@
   Box Shape
 */
 
-.c-tf-checkbox__box-shape--square {
+.box-shape--square {
   border-radius: var(--tf-checkbox-border-radius-square);
 }
 
-.c-tf-checkbox__box-shape--round {
+.box-shape--round {
   border-radius: var(--tf-checkbox-border-radius-round);
 }
 
@@ -45,7 +50,7 @@
   Checked Box
 */
 
-.c-tf-checkbox__box-shape--checked {
+.box-shape--checked {
   background-color: var(--x-color-green-5);
   border-color: var(--x-color-green-5);
   fill: var(--x-color-white);
@@ -55,7 +60,7 @@
   Disabled
 */
 
-.c-tf-checkbox__box-shape--disabled {
+.box-shape--disabled {
   background-color: var(--x-color-gray-1);
   fill: var(--x-color-gray-2);
 }
@@ -63,7 +68,12 @@
 /*
   Check Icon
 */
-.c-tf-checkbox__check-icon {
+.check-icon {
+  composes: u-block from global;
   margin: auto; /* To center the check icon in the box */
   margin-top: 0.1875rem; /* 3px - To vertically align the check in the box */
+}
+
+.checkbox-content {
+  composes: u-inline-block u-valign-middle from global;
 }

--- a/addon/templates/components/tf-checkbox.hbs
+++ b/addon/templates/components/tf-checkbox.hbs
@@ -1,15 +1,15 @@
 <input type="checkbox"
-    class="c-tf-checkbox__input-checkbox u-hidden-visually u-m-0"
+    local-class="hidden-checkbox"
     id={{checkboxId}}
     disabled={{disabled}}
     name={{name}}
     checked={{checked}}
     value={{value}}
     data-test={{hook "tf-checkbox__input-checkbox"}}>
-<label class="c-tf-checkbox__label" for={{checkboxId}} {{action "clickedCheckbox" value name id}} data-test={{hook "tf-checkbox__label"}}>
-  <div class="u-inline-block u-valign-middle c-tf-checkbox__box-shape {{boxShape}} {{if checked 'c-tf-checkbox__box-shape--checked'}} {{if disabled 'c-tf-checkbox__box-shape--disabled'}}" data-test={{hook "tf-checkbox__box-shape"}}>
+<label local-class="label" for={{checkboxId}} {{action "clickedCheckbox" value name id}} data-test={{hook "tf-checkbox__label"}}>
+  <div local-class="box-shape {{boxShape}} {{if checked 'box-shape--checked'}} {{if disabled 'box-shape--disabled'}}" data-test={{hook "tf-checkbox__box-shape"}}>
     {{#if shouldShowCheck}}
-      <svg role="img" class="u-block c-tf-checkbox__check-icon" data-test={{hook "tf-checkbox__check-icon"}} width="12px" height="9px" viewBox="0 0 12 9" preserveAspectRatio="xMidYMin" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+      <svg role="img" local-class="check-icon" data-test={{hook "tf-checkbox__check-icon"}} width="12px" height="9px" viewBox="0 0 12 9" preserveAspectRatio="xMidYMin" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
         <g id="Dev-Library" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
           <g id="TFL---Selections-Controls" transform="translate(-357.000000, -284.000000)" stroke-width="2">
             <g id="check-icon" transform="translate(354.000000, 279.000000)">
@@ -20,7 +20,7 @@
       </svg>
     {{/if}}
   </div>
-  <span class="u-inline-block u-valign-middle" data-test={{hook "tf-checkbox__content"}}>
+  <span local-class="checkbox-content" data-test={{hook "tf-checkbox__content"}}>
     {{yield}}
   </span>
 </label>

--- a/app/styles/ember-ticketfly-checkbox.css
+++ b/app/styles/ember-ticketfly-checkbox.css
@@ -1,1 +1,0 @@
-@import "components/tf-checkbox.css";

--- a/index.js
+++ b/index.js
@@ -4,11 +4,9 @@
 module.exports = {
   name: 'ember-ticketfly-checkbox',
 
-  included: function(app) {
-
-    app.import('app/styles/ember-ticketfly-checkbox.css');
-
-    this._super.included.call(this, app);
-
+  options: {
+    cssModules: {
+      // config
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.7",
-    "ember-cli-htmlbars": "^1.0.10"
+    "ember-cli-htmlbars": "^1.0.10",
+    "ember-css-modules": "0.6.4"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,5 +1,5 @@
 :root {
-  --font-family-gibson: 
+  --font-family-gibson:
     Gibson, Akkurat-Pro, Helvetica, Roboto, Arial, sans-serif;
   --font-family-akkurat-pro:
     Akkurat-Pro, Helvetica, Roboto, Arial, sans-serif;

--- a/tests/integration/components/tf-checkbox-test.js
+++ b/tests/integration/components/tf-checkbox-test.js
@@ -1,6 +1,7 @@
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 import { initialize, $hook } from 'ember-hook';
+import 'ember-css-modules/extensions';
 
 moduleForComponent('tf-checkbox', 'Integration | Component | tf checkbox', {
   beforeEach() {
@@ -48,7 +49,7 @@ test('checkboxId is not passed in', function(assert) {
 
   assert.ok(inputId, 'input has generated "id"');
   assert.ok(labelFor, 'label has "for" attribute set');
-  assert.equal(inputId, labelFor, 'input "id" matches label "for"');  
+  assert.equal(inputId, labelFor, 'input "id" matches label "for"');
 });
 
 test('renders in block form', function(assert) {
@@ -95,20 +96,20 @@ test('checked property changes on click', function(assert) {
   assert.ok(!checkboxInput.is(':checked'), "input isn't checked");
 
   $hook('tf-checkbox__label').click();
-  
+
   assert.ok(checkboxInput.is(':checked'), "input is checked");
 });
 
 test('checkbox receives a shapeStyle', function(assert) {
   this.render(hbs`{{tf-checkbox shapeStyle="round"}}`);
 
-  const boxShape = $hook('tf-checkbox__box-shape');
-  assert.ok(boxShape.hasClass('c-tf-checkbox__box-shape--round'), "box shape is round");
+  const classNames = $hook('tf-checkbox__box-shape').attr('class');
+  assert.ok(classNames.indexOf('box-shape--round') > -1, 'box shape is round');
 });
 
 test('checkbox defaults to square shape', function(assert) {
   this.render(hbs`{{tf-checkbox}}`);
 
-  const boxShape = $hook('tf-checkbox__box-shape');
-  assert.ok(boxShape.hasClass('c-tf-checkbox__box-shape--square'), "box shape is square");
+  const classNames = $hook('tf-checkbox__box-shape').attr('class');
+  assert.ok(classNames.indexOf('box-shape--square') > -1, 'box shape is square');
 });


### PR DESCRIPTION
@ksin @melissaroman  @BrianSipple 

This is a PR for what was _supposed_ to be bringing in support for `ember-css-composer`. 

The reality is that the ideas in it can be accomplished by using `ember-css-modules` — and because it has such robust community support, it seems like it'd be better solution. There are some things I think I'd like to see in `ember-css-modules`, but those can be feature requests to that repo. 

This is both a proof-of-concept and useable code. There should be no style changes. I can dig deeper into what's going on for the curious; but this at least gives us a starting point. 